### PR TITLE
Let quickheal spoil after 30 instead of 10 days

### DIFF
--- a/items.json
+++ b/items.json
@@ -12,7 +12,7 @@
     "material": [ "water" ],
     "symbol": "!",
     "freezing_point": -1000,
-	"spoils_in": "30 days",
+	"spoils_in": "10 days",
     "color": "red"
   },
   {
@@ -37,7 +37,7 @@
     "//": "What you'll find in your starter kit.",
     "subtype": "collection",
     "entries": [
-	  { "item": "quickheal", "count": 10 },
+	  { "item": "quickheal", "count": 5 },
 	  { "item": "tent_kit", "count": 1 }	  
 	]
   },

--- a/items.json
+++ b/items.json
@@ -12,7 +12,7 @@
     "material": [ "water" ],
     "symbol": "!",
     "freezing_point": -1000,
-	"spoils_in": "10 days",
+	"spoils_in": "30 days",
     "color": "red"
   },
   {


### PR DESCRIPTION
This simply increases the time until spoilage to 30 days.

If you have 10 days to use 10 quickheals, using them becomes a no-brainer. Unless you run multiple raids a day you should always use them. This trivializes problems like getting clean water, taking care of your resources etc.

Letting it spoil at all is probably a good idea because once you're setup you should have enough resources to rest for the time required to heal.