### PR TITLE
Added Overmap flag "CLASSIC" for classic_zombies compatibility

### DIFF
--- a/island.json
+++ b/island.json
@@ -173,6 +173,6 @@
     "city_sizes": [ 0, 20 ],
     "occurrences": [ 100, 100 ],
     "rotate": false,
-    "flags": [ "SAFE_AT_WORLDGEN", "GLOBALLY_UNIQUE" ]
+    "flags": [ "CLASSIC", "SAFE_AT_WORLDGEN", "GLOBALLY_UNIQUE" ]
   }
 ]


### PR DESCRIPTION
DDotD requires the "CLASSIC" flag for overmap specials: [wiki](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/JSON_FLAGS.md#overmap-specials)

Without this flag the sky island overmap is excluded as a valid overmap and produces the following:
![image](https://user-images.githubusercontent.com/77356082/219798876-10131a72-7b87-4e82-a381-b7cdda9e95a1.png)

