### PR TITLE
Port u_val time to math

### DIFF
--- a/EOCs.json
+++ b/EOCs.json
@@ -418,7 +418,7 @@
       {
         "u_message": "All difficulty settings set to default.  You can speak to the Heart of the Island to change these at any time."
       },
-      { "arithmetic": [ { "global_val": "var", "var_name": "sicknessintervals" }, "=", { "time": "15 m" } ] },
+      { "math": [ "sicknessintervals", "=", "time('15 m')" ] },
       { "math": [ "roomteleportselector", "=", "1" ] },
       { "math": [ "u_spell_level('warp_home')", "=", "-1" ] },
       { "math": [ "u_spell_level('warped_return')", "=", "-1" ] },
@@ -433,7 +433,7 @@
       {
         "u_message": "Difficulty set to Casual.  You can speak to the Heart of the Island to change this at any time."
       },
-      { "arithmetic": [ { "global_val": "var", "var_name": "sicknessintervals" }, "=", { "time": "30 m" } ] },
+      { "math": [ "sicknessintervals", "=", "time('30 m')" ] },
       { "run_eocs": "EOC_difficultycheck_2" }
     ]
   },
@@ -444,7 +444,7 @@
       {
         "u_message": "Difficulty set to Normal.  You can speak to the Heart of the Island to change this at any time."
       },
-      { "arithmetic": [ { "global_val": "var", "var_name": "sicknessintervals" }, "=", { "time": "15 m" } ] },
+      { "math": [ "sicknessintervals", "=", "time('15 m')" ] },
       { "run_eocs": "EOC_difficultycheck_2" }
     ]
   },
@@ -455,7 +455,7 @@
       {
         "u_message": "Difficulty set to Hard.  You can speak to the Heart of the Island to change this at any time."
       },
-      { "arithmetic": [ { "global_val": "var", "var_name": "sicknessintervals" }, "=", { "time": "10 m" } ] },
+      { "math": [ "sicknessintervals", "=", "time('10 m')" ] },
       { "run_eocs": "EOC_difficultycheck_2" }
     ]
   },
@@ -466,7 +466,7 @@
       {
         "u_message": "Difficulty set to Impossible.  You can speak to the Heart of the Island to change this at any time."
       },
-      { "arithmetic": [ { "global_val": "var", "var_name": "sicknessintervals" }, "=", { "time": "5 m" } ] },
+      { "math": [ "sicknessintervals", "=", "time('5 m')" ] },
       { "run_eocs": "EOC_difficultycheck_2" }
     ]
   },


### PR DESCRIPTION
Update for u_val time being ported to math. In the latest experimental as of time of writing the mod fails to load with 'unrecognised number source in { "time": "15 m" }' unless this is applied. Mirror changes from CleverRaven/Cataclysm-DDA#70996.