### PR TITLE
Mission requirement fixes of various sorts

### DIFF
--- a/recipes.json
+++ b/recipes.json
@@ -170,7 +170,7 @@
     "components": [
 	    [ [ "warptoken", 15 ] ],
 	    [ [ "id_science", 1 ] ],
-	    [ [ "oxyacetylene", 60 ] ]
+	    [ [ "microscope_dissecting", 1 ] ]
 	]
   },
   {

--- a/upgrade_missions.json
+++ b/upgrade_missions.json
@@ -1381,7 +1381,7 @@
 	    [ [ "bat", 1 ], [ "bwirebat", 1 ], [ "nailbat", 1 ] ],
 	    [ [ "warptoken", 2 ] ],
 	    [ [ "bandages", 10 ] ],
-	    [ [ "liq_bandage", 80 ] ],
+	    [ [ "liq_bandage_spray", 1 ] ],
 		[ [ "9mm", 50], [ "9mmfmj", 50 ], [ "9mmP", 30 ], [ "9mmP2", 20 ] ]
 	]
   },
@@ -1930,7 +1930,7 @@
 	    [ [ "id_science", 1 ] ],
 	    [ [ "plut_cell", 5 ] ],
 	    [ [ "oxy_torch", 1 ] ],
-		[ [ "oxyacetylene", 120 ] ],
+		[ [ "tinyweldtank", 1 ], [ "weldtank", 1 ],
 		[ [ "mutagen", 2 ], [ "iv_mutagen", 1 ] ],
 		[ [ "jackhammer", 1 ], [ "elec_jackhammer", 1 ] ]
 	]

--- a/upgrade_missions.json
+++ b/upgrade_missions.json
@@ -318,7 +318,7 @@
     "components": [
 	    [ [ "microscope_dissecting", 1 ] ],
 	    [ [ "sensor_module", 1 ] ],
-	    [ [ "holybook_wicca1", 1 ] ],
+	    [ [ "book_newage_witchcraftbeg", 1 ] ],
 	    [ [ "warptoken", 12 ] ],
 	    [ [ "platinum_small", 10 ] ],
 		[ [ "battery_car", 1], [ "battery_motorbike", 1 ], [ "medium_storage_battery", 1 ] ],


### PR DESCRIPTION
There were a couple of places where recipes asked for charges of liquid spray bandage or acetylene, but the game won't recognize it to pull it out of the container. I've changed the recipes for Labs Catalyst to need a dissecting microscope and a couple of island unlocks to use the tanks themselves.